### PR TITLE
feat: add Prettier formatter configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,30 @@
+# Dependencies
+node_modules/
+*.lock
+package-lock.json
+yarn.lock
+
+# Build output
+dist/
+build/
+*.min.js
+*.min.css
+
+# Generated files
+coverage/
+.nyc_output/
+
+# System files
+.DS_Store
+Thumbs.db
+
+# IDE/Editor files
+.vscode/
+.idea/
+
+# Temporary files
+*.tmp
+*.temp
+
+# Log files
+*.log

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,26 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "printWidth": 100,
+        "proseWrap": "preserve"
+      }
+    },
+    {
+      "files": "*.yml",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cit",
+  "version": "1.0.0",
+  "description": "GitHub operations and Claude Code integration tools",
+  "main": "index.js",
+  "scripts": {
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "echo 'No linter configured yet'",
+    "type-check": "echo 'No TypeScript configured yet'",
+    "test": "echo 'No tests configured yet'"
+  },
+  "keywords": ["github", "claude-code", "automation"],
+  "author": "hikuohiku",
+  "license": "MIT",
+  "devDependencies": {
+    "prettier": "^3.0.0"
+  }
+}


### PR DESCRIPTION
Add Prettier formatter support for Claude Code

## Changes
- Add .prettierrc with sensible formatting defaults
- Add package.json with formatter scripts
- Add .prettierignore to exclude build artifacts
- Integrates with existing code-quality.yml workflow

Closes #4

Generated with [Claude Code](https://claude.ai/code)